### PR TITLE
Close notification fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea

--- a/beta.js
+++ b/beta.js
@@ -1104,8 +1104,9 @@ if (!hello_run && Dubtrack.session.id) {
                 var options = {
                     body: content,
                     icon: "http://i.imgur.com/RXJnXNJ.png"
-                }
+                };
                 var n = new Notification("Message from "+e.user.username,options);
+                setTimeout(n.close.bind(n), 5000);
             }
         },
         spacebar_mute: function() {


### PR DESCRIPTION
This fixes web API notifications staying on screen until the user closes it manually. Automatically closes the notification after 5 seconds.