### PR TITLE
Autocomplete Enter Keypress Fixes

### DIFF
--- a/beta.js
+++ b/beta.js
@@ -922,6 +922,7 @@ if (!hello_run && Dubtrack.session.id) {
                 case 40:
                     hello.doNavigate(1);
                     break;
+                case 39:
                 case 13:
                     $('#autocomplete-preview li.selected').trigger('click');
                     break;
@@ -943,7 +944,7 @@ if (!hello_run && Dubtrack.session.id) {
                 hello.updateChatInput(new_text);
             });
 
-            $(document.body).on('keydown', '.ac-show', hello.previewListKeyUp);
+            $(document.body).on('keyup', '.ac-show', hello.previewListKeyUp);
         },
         /**************************************************************************
          * A bunch of utility helpers for the emoji preview
@@ -1026,11 +1027,11 @@ if (!hello_run && Dubtrack.session.id) {
             }
 
             if ($('.ac-show li').length === 1) {
-                $('.ac-show li').append('<span>press &darr; to select</span>').addClass('selected');
+                $('.ac-show li').append('<span>press enter to select</span>').addClass('selected');
             }
 
-            if ($('.ac-show li').length === 1 && e.keyCode === 40) {
-                $('#autocomplete-preview li.selected').trigger('click');
+            if ($('.ac-show li').length === 1 && e.keyCode === 13) {
+                $('#autocomplete-preview li:first').trigger('click');
                 return;
             }
 
@@ -1039,6 +1040,9 @@ if (!hello_run && Dubtrack.session.id) {
             }
             if (e.keyCode === 40) {
                 self.doNavigate(1);
+            }
+            if (e.keyCode === 13 && currentText.length > 0){
+                Dubtrack.room.chat.sendMessage();
             }
         },
         optionEmojiPreview: function(){
@@ -1146,6 +1150,9 @@ if (!hello_run && Dubtrack.session.id) {
             });
         },
         userAutoComplete: function(){
+            //Remove keydown event chat view to replace with our event
+            Dubtrack.room.chat.delegateEvents(_(Dubtrack.room.chat.events).omit('keydown input#chat-txt-message'));
+
             $(document.body).on('keyup', "#chat-txt-message", this.chatInputKeyupFunc);
             hello.whenAvailable("Dubtrack.room.users", hello.updateUsersArray);
             Dubtrack.Events.bind("realtime:user-ban", hello.updateUsersArray);


### PR DESCRIPTION
- Fix for selecting autocomplete options with enter when there is only one matching result
- Add ability to select a highlighted autocomplete option with the right arrow
- Override Backbone chat view keydown event with our chat input event (this is where the magic is)
  - Take a look at [beta.js#L1153](https://github.com/coryshaw1/DubX-Script/blob/autocomplete_enter_fix/beta.js#L1153) for how it's done
  - Basically remove the chat view's `keydown input#chat-txt-message` event

I based most of my autocomplete design choices off of Slack's autocompletion.