### PR TITLE
Console error for css url

### DIFF
--- a/beta.js
+++ b/beta.js
@@ -479,6 +479,9 @@ if (!hello_run && Dubtrack.session.id) {
                 }).done(function(e) {
                     var content = e.data.description;
                     var url = content.match(/(@dubx=)((https?:\/\/)?[\w-]+(\.[\w-]+)+\.?(:\d+)?(\/\S*)?)/);
+
+                    if(!url) return;
+
                     var append = url[0].split('@dubx=');
                     $('head').append('<link class="css_world" href="'+append[1]+'" rel="stylesheet" type="text/css">');
                 });


### PR DESCRIPTION
Fix for console error when room description doesn't contain a custom css url